### PR TITLE
replace getScannerRows with getScannerResults, and add new scan method for loop fetch

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -168,29 +168,13 @@ Client.prototype.Inc = function (row) {
 Client.prototype.scan = function (table, scan, callback) {
     var tScan = new HBaseTypes.TScan(scan);
     var that = this;
-    this.client.openScanner(table, tScan, function (err, scannerId) {
-
-        if (err) {
-            callback(err.message.slice(0, 120));
-            return;
-        } else {
-            that.client.getScannerRows(scannerId, scan.numRows, function (serr, data) {
-                if (serr) {
-                    callback(err.message.slice(0, 120));
-                    return;
-                } else {
-                    callback(null, data);
-                }
-            });
-            that.client.closeScanner(scannerId, function (err) {
-                if (err) {
-                    console.log(err);
-                }
-            });
+    this.client.getScannerResults(table, tScan, scan.numRows, function(serr, data){
+        if(serr){
+            callback(serr.message.slice(0, 120));
+        }else{
+            callback(null, data);
         }
-
     });
-
 };
 
 // Client.prototype.scanRow = function (table, startRow, stopRow, columns, numRows, callback) {


### PR DESCRIPTION
1. for ``` Client.prototype.scan ```:
    replace getScannerRows with getScannerResults 
    will perform less calls to the server.

2. for ``` Client.prototype.scanLoopFetch ```:
    a.  if err then closeScanner.  it is less prone to cause memory leak.
    b.  if scan data is large, loop fetch can reduce thrift server memroy use, each request thrift server get all the data back together.
